### PR TITLE
Fix empty trailing line in admins.txt bug

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -162,7 +162,7 @@ Citizen.CreateThread(function()
 			local numIds = GetPlayerIdentifiers(theKey)
 			for i,admin in ipairs(admins) do
 				for i,theId in ipairs(numIds) do
-					if admin == theId then -- is the player an admin?
+					if admin == theId .. '\r' or admin == theId then -- is the player an admin?
 						TriggerClientEvent("adminresponse", theKey, true)
 					end
 				end


### PR DESCRIPTION
Line 165 now checks for the player identifier, or the player id + '\r' (new line) which fixes the issue of a new line trailing the admins.txt, breaking the admins list.