### PR TITLE
Easier unbanning/unban refreshing through menu // IP banning

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -8,6 +8,7 @@ Citizen.CreateThread(function()
 	strings = json.decode(LoadResourceFile(GetCurrentResourceName(), "language/"..GetConvar("ea_LanguageName", "en")..".json"))[1]
 	
 	moderationNotification = GetConvar("ea_moderationNotification", "false")
+	allowIpBan = GetConvar("ea_ipBanning", "false")
 	RegisterServerEvent('EasyAdmin:amiadmin')
 	AddEventHandler('EasyAdmin:amiadmin', function()
 		local banperm = DoesPlayerHavePermission(source,"easyadmin.ban")
@@ -111,7 +112,8 @@ Citizen.CreateThread(function()
 					reason = reason.. string.format(strings.reasonadd, GetPlayerName(playerId), GetPlayerName(source) )
 					reason = string.gsub(reason, "|", "") -- filter out any characters that could break me
 					reason = string.gsub(reason, ";", "")
-					updateBlacklist( {identifier = identifier, reason = reason, expire = expires or 10444633200 } )
+					if GetPlayerIdentifiers(playerId)[3] then if allowIpBan then ipAddress = GetPlayerIdentifiers(playerId)[3] else ipAddress = 'IP banning disabled.' end else ipAddress = 'IP not found.' end
+					updateBlacklist( {identifier = identifier, ipAddress = tostring(ipAddress), reason = reason, expire = expires or 10444633200 } )
 				end
 			end
 			SendWebhookMessage(moderationNotification,string.format(strings.adminbannedplayer, GetPlayerName(source), GetPlayerName(playerId), reason))
@@ -128,7 +130,8 @@ Citizen.CreateThread(function()
 				reason = reason..string.format(strings.bancheatingadd, GetPlayerName(playerId) )
 				reason = string.gsub(reason, "|", "") -- filter out any characters that could break me
 				reason = string.gsub(reason, ";", "")
-				updateBlacklist( {identifier = identifier, reason = reason, expire = 10444633200} )
+				if GetPlayerIdentifiers(playerId)[3] then if allowIpBan then ipAddress = GetPlayerIdentifiers(playerId)[3] else ipAddress = 'IP banning disabled.' end else ipAddress = 'IP not found.' end
+				updateBlacklist( {identifier = identifier, ipAddress = tostring(ipAddress), reason = reason, expire = expires or 10444633200 } )
 			end
 		end
 		DropPlayer(playerId, strings.bancheating)
@@ -199,7 +202,8 @@ Citizen.CreateThread(function()
 						reason = reason.. string.format(strings.reasonadd, GetPlayerName(args[1]), GetPlayerName(source) )
 						reason = string.gsub(reason, "|", "") -- filter out any characters that could break me
 						reason = string.gsub(reason, ";", "")
-						updateBlacklist( {identifier = identifier, reason = reason, expire = 10444633200} )
+						if GetPlayerIdentifiers(playerId)[3] then if allowIpBan then ipAddress = GetPlayerIdentifiers(playerId)[3] else ipAddress = 'IP banning disabled.' end else ipAddress = 'IP not found.' end
+						updateBlacklist( {identifier = identifier, ipAddress = tostring(ipAddress), reason = reason, expire = expires or 10444633200 } )
 					end
 				end
 				SendWebhookMessage(moderationNotification,string.format(strings.adminbannedplayer, GetPlayerName(source), GetPlayerName(args[1]), reason))
@@ -400,7 +404,8 @@ Citizen.CreateThread(function()
 		local numIds = GetPlayerIdentifiers(source)
 		for bi,blacklisted in ipairs(blacklist) do
 			for i,theId in ipairs(numIds) do
-				if blacklisted.identifier == theId then
+				if blacklisted.ipAddress then ipAddress = blacklisted.ipAddress else ipAddress = 'No IP found.' end
+				if ipAddress == GetPlayerIdentifiers(source)[3] or blacklisted.identifier == theId then
 					Citizen.Trace("user is banned")
 					setKickReason(string.format( strings.bannedjoin, blacklist[bi].reason, os.date('%d/%m/%Y 	%H:%M:%S', blacklist[bi].expire )))
 					print("Connection Refused, Blacklisted for "..blacklist[bi].reason.."!\n")

--- a/gui_c.lua
+++ b/gui_c.lua
@@ -284,10 +284,12 @@ function GenerateMenu() -- this is a big ass function
 			local thisItem = NativeUI.CreateItem(reason, strings.unbanplayerguide)
 			unbanPlayer:AddItem(thisItem)
 			thisItem.Activated = function(ParentMenu,SelectedItem)
-				TriggerServerEvent("EasyAdmin:unbanPlayer", identifier)
+				TriggerServerEvent("EasyAdmin:unbanPlayer", banlist[i].identifier)
 				TriggerServerEvent("EasyAdmin:updateBanlist")
-				mainMenu:Visible(false)
+				unbanPlayer:Visible(false)
+				Citizen.Wait(1000)
 				GenerateMenu()
+				unbanPlayer:Visible(true)
 			end
 		end
 	end
@@ -314,10 +316,12 @@ function GenerateMenu() -- this is a big ass function
 	if permissions.unban then
 		local thisItem = NativeUI.CreateItem(strings.refreshbanlist, strings.refreshbanlistguide)
 		settingsMenu:AddItem(thisItem)
-		settingsMenu.OnItemSelect = function(sender, item, index)
-			if item == thisItem then
-				TriggerServerEvent("EasyAdmin:updateBanlist")
-			end
+		thisItem.Activated = function(ParentMenu,SelectedItem)
+			TriggerServerEvent("EasyAdmin:updateBanlist")
+			settingsMenu:Visible(false)
+			Wait(2000)
+			GenerateMenu()
+			settingsMenu:Visible(true)
 		end
 	end
 	


### PR DESCRIPTION
Making the unban player list update on player ban. Also fix the unbanning issue by using 'banlist[i].identifier' instead of the var identifier. Also fixed the refresh banlist so you do not need to reopen menu.