### PR TITLE
Fix usage of nil value redit

### DIFF
--- a/admin_server.lua
+++ b/admin_server.lua
@@ -126,7 +126,7 @@ Citizen.CreateThread(function()
 		if playerId ~= nil then
 			local playerName = GetPlayerName(playerId)
 			if playerName ~= nil then		
-				if DoesPlayerHavePermission(source,"easyadmin.ban") and GetPlayerName(playerId) == username and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
+				if DoesPlayerHavePermission(source,"easyadmin.ban") and playerName == username and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
 					local playerLicense = ""
 					local playerSteamid = ""
 					local playerDiscordid = ""

--- a/admin_server.lua
+++ b/admin_server.lua
@@ -124,31 +124,34 @@ Citizen.CreateThread(function()
 	RegisterServerEvent("EasyAdmin:banPlayer")
 	AddEventHandler('EasyAdmin:banPlayer', function(playerId,reason,expires,username)
 		if playerId ~= nil then
-			if DoesPlayerHavePermission(source,"easyadmin.ban") and GetPlayerName(playerId) == username and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
-				local playerLicense = ""
-				local playerSteamid = ""
-				local playerDiscordid = ""
-				local bannedIdentifiers = GetPlayerIdentifiers(playerId)
-				if expires < os.time() then
-					expires = os.time()+expires 
-				end
-				for i,identifier in ipairs(bannedIdentifiers) do
-					if string.find(identifier, "license:") then
-						playerLicense = identifier
-					elseif string.find(identifier, "steam:") then
-						playerSteamid = identifier
-					elseif string.find(identifier, "discord:") then
-						playerDiscordid = identifier
+			local playerName = GetPlayerName(playerId)
+			if playerName ~= nil then		
+				if DoesPlayerHavePermission(source,"easyadmin.ban") and GetPlayerName(playerId) == username and not DoesPlayerHavePermission(playerId,"easyadmin.immune") then
+					local playerLicense = ""
+					local playerSteamid = ""
+					local playerDiscordid = ""
+					local bannedIdentifiers = GetPlayerIdentifiers(playerId)
+					if expires < os.time() then
+						expires = os.time()+expires 
 					end
-				end
-				reason = reason.. string.format(strings.reasonadd, GetPlayerName(playerId), GetPlayerName(source) )
-				local ban = {identifier = playerLicense, reason = reason, expire = expires or 10444633200 }
-				ban["steam"] = playerSteamid
-				ban["discord"] = playerDiscordid
-				updateBlacklist( ban )
+					for i,identifier in ipairs(bannedIdentifiers) do
+						if string.find(identifier, "license:") then
+							playerLicense = identifier
+						elseif string.find(identifier, "steam:") then
+							playerSteamid = identifier
+						elseif string.find(identifier, "discord:") then
+							playerDiscordid = identifier
+						end
+					end
+					reason = reason.. string.format(strings.reasonadd, GetPlayerName(playerId), GetPlayerName(source) )
+					local ban = {identifier = playerLicense, reason = reason, expire = expires or 10444633200 }
+					ban["steam"] = playerSteamid
+					ban["discord"] = playerDiscordid
+					updateBlacklist( ban )
 
-				SendWebhookMessage(moderationNotification,string.format(strings.adminbannedplayer, GetPlayerName(source), GetPlayerName(playerId), reason, os.date('%d/%m/%Y 	%H:%M:%S', expires ) ))
-				DropPlayer(playerId, string.format(strings.banned, reason, os.date('%d/%m/%Y 	%H:%M:%S', expires ) ) )
+					SendWebhookMessage(moderationNotification,string.format(strings.adminbannedplayer, GetPlayerName(source), GetPlayerName(playerId), reason, os.date('%d/%m/%Y 	%H:%M:%S', expires ) ))
+					DropPlayer(playerId, string.format(strings.banned, reason, os.date('%d/%m/%Y 	%H:%M:%S', expires ) ) )
+				end
 			end
 		end
 	end)


### PR DESCRIPTION
Since last update ( #76 ) I'm still having the same error:

```
InvokeNative: execution failed: Argument at index 0 was null.
Error running system event handling function for resource EasyAdmin: citizen:/scripting/lua/scheduler.lua:41: Failed to execute thread: Execution of native 00000000406b4b20 in script host failed.
stack traceback:
        [C]: in upvalue '_in'
        citizen:/scripting/lua/natives_server.lua:194: in function 'GetPlayerName'
        @EasyAdmin/admin_server.lua:127: in upvalue 'handler'
        citizen:/scripting/lua/scheduler.lua:219: in function <citizen:/scripting/lua/scheduler.lua:218>
stack traceback:
        [C]: in function 'error'
        citizen:/scripting/lua/scheduler.lua:41: in field 'CreateThreadNow'
        citizen:/scripting/lua/scheduler.lua:218: in function <citizen:/scripting/lua/scheduler.lua:182>
```
it's a sporadic error (it's a OneSync server) that's why it's hard for me to detect. 

I have already corrected other similar errors (error when invoking the native GetPlayerName). 
Indicates null value in index 0 
[https://runtime.fivem.net/doc/natives/#_0x406B4B20](https://runtime.fivem.net/doc/natives/#_0x406B4B20)

In the previous correction the native function was invoked within a comparison, which could be forcing to use the function response (which is a null value). Can you check that?


