### PR TITLE
 Fix ',' which made newer artifacts dont load EA

### DIFF
--- a/language/cs.json
+++ b/language/cs.json
@@ -123,7 +123,7 @@
 	"reportbantext":"Nahlaseno %s hraci v kratky cas.",
 	"alreadyreported":"Tohoto hrace jsi uz nahlasil!",
 	"reportedusageerror":"Chyba! Pouziti: /report jmeno duvod",
-	"admincalled":"Uspesne jsi zavolal admina!",
+	"admincalled":"Uspesne jsi zavolal admina!"
 
 	}
 ]

--- a/language/en.json
+++ b/language/en.json
@@ -123,7 +123,7 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
 
 	}
 ]

--- a/language/es.json
+++ b/language/es.json
@@ -123,7 +123,7 @@
 	"reportbantext":"Reportado por %s jugadores en poco tiempo.",
 	"alreadyreported":"Ya has reportado a este jugador!",
 	"reportedusageerror":"Error! Usa: /report nombre razón",
-	"admincalled":"Se ha avisado a un administrador correctamente!",
+	"admincalled":"Se ha avisado a un administrador correctamente!"
 
 	}
 ]

--- a/language/fr.json
+++ b/language/fr.json
@@ -124,6 +124,6 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
 	}
 ]

--- a/language/it.json
+++ b/language/it.json
@@ -125,6 +125,6 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
 	}
 ]

--- a/language/nl.json
+++ b/language/nl.json
@@ -125,6 +125,6 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
     }
 ]

--- a/language/pl.json
+++ b/language/pl.json
@@ -123,6 +123,6 @@
 	"reportbantext":"Zreportował %s Graczy w krótkim czasie.",
 	"alreadyreported":"Już zreportowałeś tego gracza!",
 	"reportedusageerror":"Błąd! Użyj: /report nick powód",
-	"admincalled":"Pomyślnie zawiadomiono Administratora!",
+	"admincalled":"Pomyślnie zawiadomiono Administratora!"
 	}
 ]

--- a/language/pt.json
+++ b/language/pt.json
@@ -120,6 +120,6 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
 	}
 ]

--- a/language/sv.json
+++ b/language/sv.json
@@ -124,6 +124,6 @@
 	"reportbantext":"Reported by %s Players in short time.",
 	"alreadyreported":"You already reported this player!",
 	"reportedusageerror":"Error! Usage: /report name reason",
-	"admincalled":"Successfully called an Admin!",
+	"admincalled":"Successfully called an Admin!"
 	}
 ]


### PR DESCRIPTION
For quite some time there was a  leftover ',' at the end of some json files which makes the newer artifact versions (2666 -maybe even older ones) dont load EA cause of the new json handling.
